### PR TITLE
use new urls module

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns
+from django.conf.urls import patterns
 
 urlpatterns = patterns('langcodes.views',
     (r'^langs.json', 'search'),


### PR DESCRIPTION
django.conf.urls.defaults is deprecated and removed in Django 1.6