### PR TITLE
Convert jQuery ui autocomplete to select2

### DIFF
--- a/static/langcodes/js/langcodes.js
+++ b/static/langcodes/js/langcodes.js
@@ -1,20 +1,32 @@
 jQuery.prototype.langcodes = function() {
-    return this.autocomplete({
-        source: function( request, response ) {
-            $.ajax({
-                url: "/langcodes/langs.json",
-                data: request,
-                dataType: 'json',
-                success: function( data ) {
-                    response($.map( data, function( item ) {
-                        return {
-                            label: item.code + " (" + item.name + ") ",
-                            value: item.code
-                        }
-                    }));
-                }
+    return this.select2({
+        minimumInputLength: 0,
+        delay: 100,
+        initSelection: function(element, callback) {
+            callback({
+                id: element.val(),
+                text: element.val(),
             });
         },
-        minLength: 0
+        ajax: {
+            url: "/langcodes/langs.json",
+            data: function(term) {
+                return {
+                    term: term,
+                };
+            },
+            dataType: 'json',
+            results: function(data) {
+                return {
+                    results: $.map(data, function(item) {
+                        return {
+                            text: item.code + " (" + item.name + ") ",
+                            id: item.code,
+                        };
+                    }),
+                };
+            },
+            cache: true,
+        },
     });
 }


### PR DESCRIPTION
Been meaning to get rid of jQuery UI autocompletes for a while, did it in Vellum a while back. The final nail in the coffin is that they aren't compatible with jQuery 3.

@calellowitz 