### PR TITLE
Add the Ila language from Zambia

### DIFF
--- a/langs.json
+++ b/langs.json
@@ -947,7 +947,7 @@
     {
         "names": ["Ila - Zambia"],
         "two": "",
-        "three": "ila"
+        "three": "ilb"
     },
     {
         "names": ["Interlingue", "Occidental"],

--- a/langs.json
+++ b/langs.json
@@ -945,6 +945,11 @@
         "three": "iku"
     },
     {
+        "names": ["Ila - Zambia"],
+        "two": "",
+        "three": "ila"
+    },
+    {
         "names": ["Interlingue", "Occidental"],
         "two": "ie",
         "three": "ile"


### PR DESCRIPTION
Adds the language of the [Ila people from Zambia](https://en.wikipedia.org/wiki/Ila_people).

![screen shot 2019-01-18 at 3 33 40 pm](https://user-images.githubusercontent.com/716573/51414088-d1968f80-1b36-11e9-87ae-2c6a86281b85.png)
