### PR TITLE
use non-relative import in urls.py

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from django.conf.urls import url
 
-from .views import search, validate
+from langcodes.views import search, validate
 
 urlpatterns = [
     url(r'^langs.json', search, name='search'),


### PR DESCRIPTION
In celery 4, the startup scripts call ```django.setup```, which fails due to ```ValueError: Attempted relative import in non-package```.  This change fixes that problem, which removes the need to call ```django.setup``` in the CCHQ celery configuration script, which in turn solves a bug where ```.delay()``` would block indefinitely if called from a celery task.

@dannyroberts 