### PR TITLE
django.conf.urls.url() is deprecated

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from django.conf.urls import url
+from django.conf.urls import re_path as url
 
 from langcodes.views import search, validate
 


### PR DESCRIPTION
Use django.urls.re_path() instead.
https://docs.djangoproject.com/en/4.0/releases/3.1/#id2