### PR TITLE
Import re_path from django.urls directly

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from django.conf.urls import re_path as url
+from django.urls import re_path as url
 
 from langcodes.views import search, validate
 


### PR DESCRIPTION
django.conf.urls.url alias to django.urls.re_path was deprecated in Django 3.1 and removed in Django 4.0. This works on both 3.2 and 4.2.