### PR TITLE
Use JsonResponse for json data

### DIFF
--- a/views.py
+++ b/views.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from collections import defaultdict
 
 from django.http import JsonResponse

--- a/views.py
+++ b/views.py
@@ -1,9 +1,11 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 from collections import defaultdict
-from django.http import HttpResponse
-import json
-from langcodes import langs as all_langs, grandfathered
+
+from django.http import JsonResponse
+
+from langcodes import grandfathered
+from langcodes import langs as all_langs
 
 code_key = defaultdict(lambda: "three")
 for two in grandfathered:
@@ -38,7 +40,7 @@ def search(request):
         for lang in all_langs:
             langs.append(format_lang(lang))
     
-    return HttpResponse(json.dumps(langs))
+    return JsonResponse(langs, safe=False)
 
 def validate(request):
     q = request.GET.get('term') or ''
@@ -79,7 +81,7 @@ def validate(request):
                 sug_codes.add(sug['code'])
         return suggestions
     suggestions = filter_suggestions(suggestions)
-    return HttpResponse(json.dumps({
+    return JsonResponse({
         "match":  match,
         "suggestions": suggestions,
-    }))
+    })


### PR DESCRIPTION
Part of [SAAS-15890 ](https://dimagi.atlassian.net/browse/SAAS-15890) and relates to https://github.com/dimagi/commcare-hq/pull/35110

Returns a `JsonResponse` (which automatically serializes data and applies `application/json` content-type) - versus a generic `HttpResponse` which defaults to `text/html` content-type, and is incorrect here. Also applies isort to imports, since imports were modified here anyway.

I believe this is low risk, but it should get general QA along with https://github.com/dimagi/commcare-hq/pull/35110